### PR TITLE
Simple debug mode

### DIFF
--- a/pictureflow/__init__.py
+++ b/pictureflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from .core import Session
 from .core import Placeholder

--- a/pictureflow/core/node.py
+++ b/pictureflow/core/node.py
@@ -25,7 +25,7 @@ class Node(object):
 
         self._iterator = self._get_iterator()
 
-        self.parents = parents
+        self.parents = list(parents)
 
     def _validate_parent_types(self, parents):
         if self._typecheck_enabled:

--- a/pictureflow/core/session.py
+++ b/pictureflow/core/session.py
@@ -1,5 +1,9 @@
 from copy import deepcopy
 
+from queue import Queue
+
+import pictureflow as pf
+
 
 class _PlaceholderGenerator(object):
 
@@ -37,15 +41,49 @@ class SessionWrapper(object):
         ctx: Placeholder context
     """
 
+    _EXCLUDED_DEBUG_NODES = []
+
     def __init__(self, ctx):
         self._ctx = ctx
 
-    def run(self, graph):
+    @staticmethod
+    def _attach_debug_outputs(graph):
+        queue = Queue()
+        queue.put(graph)
+
+        while not queue.empty():
+            node = queue.get()
+
+            if hasattr(node, 'parents'):
+                for i, parent in enumerate(node.parents):
+                    if hasattr(parent, '_output_type') and parent._output_type == pf.Image:
+                        disk = pf.output.DiskOutput(parent, pf.Constant('debug/'), pf.Constant('debug-disk'))
+                        disk._debug = True
+
+                        node.parents[i] = disk
+
+                    queue.put(parent)
+
+    @staticmethod
+    def _detach_debug_outputs(graph):
+        queue = Queue()
+        queue.put(graph)
+
+        while not queue.empty():
+            node = queue.get()
+
+            if hasattr(node, 'parents'):
+                for i, parent in enumerate(node.parents):
+                    if isinstance(parent, pf.output.DiskOutput) and hasattr(parent, '_debug'):
+                        node.parents[i] = parent.parents[1]  # A disk output can only have one parent
+
+    def run(self, graph, debug=False):
         """
         Do a lazy run of a transformation graph
 
         Args:
             graph (Node): Graph to execute
+            debug (bool): Debug mode
 
         Returns:
             iterator: Results iterator
@@ -56,6 +94,9 @@ class SessionWrapper(object):
             # TODO: Check for iterable dimensions
             placeholder.parents = [_PlaceholderGenerator(values)]
 
+        if debug:
+            self._attach_debug_outputs(graph)
+
         graph.reset()
 
         for itm in graph:
@@ -65,12 +106,16 @@ class SessionWrapper(object):
         for placeholder in self._ctx:
             placeholder.parents = []
 
-    def run_sync(self, graph):
+        if debug:
+            self._detach_debug_outputs(graph)
+
+    def run_sync(self, graph, debug=False):
         """
         Do a synchronous run of a transformation graph.
 
         Args:
             graph (Node): Graph to execute
+            debug (bool): Debug mode
 
         Returns:
             list: List of results
@@ -78,7 +123,7 @@ class SessionWrapper(object):
         """
         out = []
 
-        for itm in self.run(graph):
+        for itm in self.run(graph, debug):
             out.append(itm)
 
         return out

--- a/pictureflow/core/session.py
+++ b/pictureflow/core/session.py
@@ -57,9 +57,10 @@ class SessionWrapper(object):
             if hasattr(node, 'parents'):
                 for i, parent in enumerate(node.parents):
                     if hasattr(parent, '_output_type') and parent._output_type == pf.Image:
-                        disk = pf.output.DiskOutput(parent, pf.Constant('debug/'), pf.Constant('debug-disk'))
+                        disk = pf.output.DiskOutput(parent, pf.Constant('debug/'))
                         disk._debug = True
 
+                        print('Adding')
                         node.parents[i] = disk
 
                     queue.put(parent)
@@ -75,7 +76,9 @@ class SessionWrapper(object):
             if hasattr(node, 'parents'):
                 for i, parent in enumerate(node.parents):
                     if isinstance(parent, pf.output.DiskOutput) and hasattr(parent, '_debug'):
-                        node.parents[i] = parent.parents[1]  # A disk output can only have one parent
+                        node.parents[i] = parent.parents[0]
+
+                    queue.put(parent)
 
     def run(self, graph, debug=False):
         """

--- a/pictureflow/core/session.py
+++ b/pictureflow/core/session.py
@@ -59,8 +59,6 @@ class SessionWrapper(object):
                     if hasattr(parent, '_output_type') and parent._output_type == pf.Image:
                         disk = pf.output.DiskOutput(parent, pf.Constant('debug/'))
                         disk._debug = True
-
-                        print('Adding')
                         node.parents[i] = disk
 
                     queue.put(parent)

--- a/test/test_core/test_node.py
+++ b/test/test_core/test_node.py
@@ -39,7 +39,7 @@ class TestNodeInitialization(unittest.TestCase):
         self.assertFalse(n._typecheck_enabled)
 
     def test_node_sets_parents(self):
-        parents = ('a', 'b', 'c')
+        parents = ['a', 'b', 'c']
 
         n = pf.core.Node('node', *parents)
 

--- a/test/test_core/test_session.py
+++ b/test/test_core/test_session.py
@@ -1,4 +1,8 @@
+from queue import Queue
+
 from test.context import pf
+
+from unittest.mock import patch
 
 import unittest
 
@@ -54,6 +58,51 @@ class TestSessionWrapperRun(unittest.TestCase):
             next(generator)
             self.assertEqual(len(placeholder.parents), 1)
 
+    @patch('pictureflow.core.session.SessionWrapper._attach_debug_outputs')
+    def test_sessionwrapper_run_calls_attach_debug_when_in_debug(self, mock_attach):
+        placeholder = pf.Placeholder(out_type=int)
+
+        ctx = {placeholder: [1, 2, 3]}
+
+        with pf.Session(ctx) as sess:
+            generator = sess.run(placeholder, debug=True)
+            next(generator)
+            self.assertTrue(mock_attach.called)
+
+    @patch('pictureflow.core.session.SessionWrapper._attach_debug_outputs')
+    def test_sessionwrapper_run_doesnt_call_attach_debug_when_not_in_debug(self, mock_attach):
+        placeholder = pf.Placeholder(out_type=int)
+
+        ctx = {placeholder: [1, 2, 3]}
+
+        with pf.Session(ctx) as sess:
+            generator = sess.run(placeholder, debug=False)
+            next(generator)
+            self.assertFalse(mock_attach.called)
+
+    @patch('pictureflow.core.session.SessionWrapper._detach_debug_outputs')
+    def test_sessionwrapper_run_calls_detach_debug_when_in_debug(self, mock_detach):
+        placeholder = pf.Placeholder(out_type=int)
+
+        ctx = {placeholder: [1, 2, 3]}
+
+        with pf.Session(ctx) as sess:
+            generator = sess.run(placeholder, debug=True)
+            _ = [x for x in generator]
+            self.assertTrue(mock_detach.called)
+
+    @patch('pictureflow.core.session.SessionWrapper._detach_debug_outputs')
+    def test_sessionwrapper_run_doesnt_call_detach_debug_when_not_in_debug(self, mock_detach):
+        placeholder = pf.Placeholder(out_type=int)
+
+        ctx = {placeholder: [1, 2, 3]}
+
+        with pf.Session(ctx) as sess:
+            generator = sess.run(placeholder, debug=False)
+            _ = [x for x in generator]
+
+            self.assertFalse(mock_detach.called)
+
     def test_sessionwrapper_run_removes_generators_after_run(self):
 
         placeholder = pf.Placeholder(out_type=int)
@@ -89,3 +138,40 @@ class TestSessionWrapperRunSync(unittest.TestCase):
             output = sess.run_sync(placeholder)
 
         self.assertEqual(output, ctx[placeholder])
+
+
+class TestSessionWrapperAttachOutputs(unittest.TestCase):
+
+    @staticmethod
+    def _get_graph():
+        graph = pf.Placeholder(out_type=pf.Image)
+
+        graph = pf.transform.Rotate(graph, rot_angle=pf.Constant(90))
+        graph = pf.transform.Scale(graph, scale_factor=pf.Constant(0.1))
+
+        graph = pf.output.DiskOutput(graph, base_path=pf.Constant('data/output/'))
+
+        return graph
+
+    def test_attach_debug_outputs_appends_the_correct_number_of_disk_outputs(self):
+        graph = TestSessionWrapperAttachOutputs._get_graph()
+        expected_debug_out_count = 3
+
+        pf.core.session.SessionWrapper._attach_debug_outputs(graph)
+
+        queue = Queue()
+        queue.put(graph)
+
+        actual_debug_out_count = 0
+
+        while not queue.empty():
+            node = queue.get()
+
+            if isinstance(node, pf.output.DiskOutput) and hasattr(node, '_debug'):
+                actual_debug_out_count += 1
+
+            if hasattr(node, 'parents'):
+                for parent in node.parents:
+                    queue.put(parent)
+
+        self.assertEqual(actual_debug_out_count, expected_debug_out_count)

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,17 @@
+box: python:3.6
+
+build:
+
+  steps:
+    - pip-install
+
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
+
+    - script:
+        name: python unit tests
+        code: |
+          python -m unittest discover -v -s test


### PR DESCRIPTION
This PR adds a simple debug mode for pictureflow. For now, it simply writes every image transformation step with a unique id under the `debug/` directory, but I'm open to feature requests :) 